### PR TITLE
fix: 换图时保持分析面板挂载，消除右侧区域闪烁

### DIFF
--- a/components/AnalysisResultPanel.vue
+++ b/components/AnalysisResultPanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="glass-panel analysis-panel">
-    <Transition name="fade-swap" mode="out-in">
+    <Transition name="fade-swap">
       <div v-if="viewPhase === 'analyzing'" key="loading" class="glass-content analyzing-wrap">
         <div class="analyzing-ring">
           <div class="analyzing-portrait-wrap">

--- a/pages/[id].vue
+++ b/pages/[id].vue
@@ -147,7 +147,7 @@ const displayImageSrc = computed(() => {
 const viewPhase = computed<'idle' | 'analyzing' | 'resolved'>(() => {
   if (loading.value) return 'analyzing'
   if (result.value) return 'resolved'
-  if (!analyzeMode.value) return 'idle'
+  if (analyzeMode.value && !notFound.value) return 'analyzing'
   return 'idle'
 })
 
@@ -288,7 +288,8 @@ async function switchToRandom() {
 async function loadArtwork() {
   error.value = ''
   notFound.value = false
-  loading.value = false
+  if (analyzeMode.value) loading.value = true
+  else loading.value = false
   manualResult.value = null
   if (uploadedImageUrl.value) {
     URL.revokeObjectURL(uploadedImageUrl.value)
@@ -317,7 +318,6 @@ async function loadArtwork() {
     if (analyzeMode.value && !a.analysisResult) {
       const autoKey = `auto:${a.id}:${a.imageUrl}`
       if (inFlightAnalyzeKey.value === autoKey) return
-      loading.value = true
       inFlightAnalyzeKey.value = autoKey
       try {
         const res = await classifyByUrl(a.imageUrl)


### PR DESCRIPTION
分析态下 viewPhase 不再落入 idle，换图时先进入 loading 再清数据，并移除 out-in 过渡。